### PR TITLE
:dependabot: subscribe to dependabot for npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+---
+
+version: 2
+
+updates:
+
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ':dependabot'
+    reviewers:
+      - duncdrum
+
+...


### PR DESCRIPTION
have dependabot run weekly checks for updates of the project's npm dependencies in `package.json`/`package-lock.json`.